### PR TITLE
[Bug]RetryableHttpClient - unseekable body stream

### DIFF
--- a/src/Symfony/Component/HttpClient/RetryableHttpClient.php
+++ b/src/Symfony/Component/HttpClient/RetryableHttpClient.php
@@ -129,7 +129,7 @@ class RetryableHttpClient implements HttpClientInterface, ResetInterface
             $context->pause($delay / 1000);
 
             if ($retryCount >= $this->maxRetries) {
-                $context->passthru();
+                yield from $this->passthru($context, $firstChunk, $content, $chunk);
             }
         });
     }


### PR DESCRIPTION
Hi, guys, I think there is an issue with the RetryableHttpClient, let me explain to you what I've seen.

1. Request is executed into AsyncResponse::__construct

2. The initializer Closure executes AsyncResponse::passthru, there the AsyncContext and a new stream are created

3. The next step is yielding from passthruStream and there the stream is checked - ```$r->stream->valid()```. Here the stream is not a valid iterator, because the last retry attempt has already been made and the generator is closed. 

4. This leads the response body stream to be unseekable because the ```$r->openBuffer()``` is not called. The content is left with a value ```null``` and when ```AsyncResponse->toStream()``` is called from ```Psr18Client::110``` the content with value null is bound to the ```content of StreamWrapper```.

5. After that this newly generated resource is passed to the ```Psr17Factory->createStreamFromResource()``` and the resulted (unseekable body) stream is passed to the ```$response->withBody($body)``` onto ```Psr18Client::121```

6. The result is that the Response body stream is not seekable and when I execute two times ```(string) $response->getBody()``` after the first attempt the body is an empty string.

Let me know what you think. 

Thank you.

| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.  
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
